### PR TITLE
 Replace wireframe cube with solid, rotating coloured cube on a green background

### DIFF
--- a/src/samples/DX11/PixelShader.hlsl
+++ b/src/samples/DX11/PixelShader.hlsl
@@ -1,4 +1,10 @@
-float4 main() : SV_TARGET
+struct PixelInputType
 {
-	return float4(1.0f, 1.0f, 1.0f, 1.0f);
+    float4 position : SV_POSITION;
+	float4 col : COLOR;
+};
+
+float4 main(PixelInputType input) : SV_TARGET
+{
+	return float4(input.col.xyz, 1.0);
 }

--- a/src/samples/DX11/VertexShader.hlsl
+++ b/src/samples/DX11/VertexShader.hlsl
@@ -3,7 +3,16 @@ cbuffer WorldViewProjectionConstantBuffer : register(b0)
     matrix worldViewProjMatrix;
 };
 
-float4 main( float4 pos : POSITION ) : SV_POSITION
+struct PixelInputType
 {
-	return mul(pos, worldViewProjMatrix);
+    float4 position : SV_POSITION;
+    float4 col : COLOR;
+};
+
+PixelInputType main(float4 pos : POSITION)
+{
+    PixelInputType p;
+    p.position = mul(pos, worldViewProjMatrix);
+    p.col = pos + float4(0.5, 0.5, 0.5, 0.5);
+    return p;
 }


### PR DESCRIPTION
![cubeee](https://user-images.githubusercontent.com/80043790/134162933-3983f568-f349-4d67-a318-0a58da726497.PNG)

Easier to verify for debugging purposes - moves, no black background, can be picked out in a downscaled image.