### PR TITLE
Add working colour space support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# RS3.0
+
+Compatible with disguise designer version r31.1 and above.
+* Added project working colour space in schema
+
 # RS2.0
 Compatible with disguise designer version r25.0 and above.
 * Removed unused parameters from D3TrackingData

--- a/src/include/d3renderstream.h
+++ b/src/include/d3renderstream.h
@@ -250,6 +250,19 @@ enum RemoteParameterDmxType
     RS_DMX_16_BE,
 };
 
+enum RSColourSpace
+{
+    RS_COLOUR_SPACE_UNKNOWN,
+    RS_COLOUR_SPACE_sRGBCurve,
+    // All colour spaces are linear by default
+    RS_COLOUR_SPACE_sRGB,
+    RS_COLOUR_SPACE_Rec2020,
+    RS_COLOUR_SPACE_ACES2065,
+    RS_COLOUR_SPACE_ACEScg,
+    RS_COLOUR_SPACE_P3D65,
+    RS_COLOUR_SPACE_P3DCI,
+};
+
 typedef struct
 {
     float min;
@@ -317,6 +330,7 @@ typedef struct
     const char* engineVersion;
     const char* pluginVersion;
     const char* info;
+    RSColourSpace workingColourSpace;
     Channels channels;
     Scenes scenes;
 } Schema;
@@ -331,7 +345,7 @@ typedef struct
 
 #define D3_RENDER_STREAM_API __declspec( dllexport )
 
-#define RENDER_STREAM_VERSION_MAJOR 2
+#define RENDER_STREAM_VERSION_MAJOR 3
 #define RENDER_STREAM_VERSION_MINOR 0
 
 #define RENDER_STREAM_VERSION_STRING stringify(RENDER_STREAM_VERSION_MAJOR) "." stringify(RENDER_STREAM_VERSION_MINOR)

--- a/src/include/renderstream.hpp
+++ b/src/include/renderstream.hpp
@@ -497,6 +497,7 @@ private:
         schema.engineVersion = nullptr;
         schema.pluginVersion = nullptr;
         schema.info = nullptr;
+        schema.workingColourSpace = RSColourSpace::RS_COLOUR_SPACE_UNKNOWN;
         schema.channels.nChannels = 0;
         schema.channels.channels = nullptr;
         schema.scenes.nScenes = 0;

--- a/src/samples/Schema/Schema.cpp
+++ b/src/samples/Schema/Schema.cpp
@@ -70,6 +70,7 @@ int mainImpl(int argc, char** argv)
     scoped.schema.engineVersion = _strdup(("RS" + std::to_string(RENDER_STREAM_VERSION_MAJOR) + "." + std::to_string(RENDER_STREAM_VERSION_MINOR)).c_str());
     scoped.schema.pluginVersion = _strdup(("RS" + std::to_string(RENDER_STREAM_VERSION_MAJOR) + "." + std::to_string(RENDER_STREAM_VERSION_MINOR) + "-Samples").c_str());
     scoped.schema.info = _strdup("");
+    scoped.schema.workingColourSpace = RSColourSpace::RS_COLOUR_SPACE_UNKNOWN;
     scoped.schema.channels.nChannels = static_cast<uint32_t>(channels.size());
     scoped.schema.channels.channels = channels.data();
     scoped.schema.scenes.nScenes = 2;


### PR DESCRIPTION
# Add working colour space support

> https://d3technologies.atlassian.net/browse/RSP-353

## Linked PR

- https://github.com/disguise-one/d3/pull/3178
- https://github.com/disguise-one/RenderStream-UE/pull/102
- https://github.com/disguise-one/RenderStream-Unity/pull/24

## Summary

Designer must aware of Unreal Engine’s working colour space when implementing texture sharing. Because texture sharing is bypassed until the end of UE’s rendering pipeline, Designer needs to account for the UE working colour space, so when colour transform (Transform Source -> Transform Destination) is applied, texture sharing texture also can produce a correct colour. Adding a new `workingColourSpace` field in the Schema for this.

Note that this also include the major version update from `RS2.0` to `RS3.0`