### PR TITLE
New API endpoint for registering texture parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # RS3.0
 
-Compatible with disguise designer version rXX.x(need to be updated before releasing RS3.0) and above.
+Compatible with disguise designer version r33.3 and above.
 * Added project working colour space in schema
 * When using texture parameters, the engine is required to call `rs_registerTextureParams` to register the received frames before they are used. This must be called from a render thread.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # RS3.0
 
-Compatible with disguise designer version r31.1 and above.
+Compatible with disguise designer version rXX.x(need to be updated before releasing RS3.0) and above.
 * Added project working colour space in schema
+* When using texture parameters, the engine is required to call `rs_registerTextureParams` to register the received frames before they are used. This must be called from a render thread.
 
 # RS2.0
 Compatible with disguise designer version r25.0 and above.

--- a/src/include/d3renderstream.h
+++ b/src/include/d3renderstream.h
@@ -437,6 +437,7 @@ extern "C" D3_RENDER_STREAM_API RS_ERROR rs_beginFollowerFrame(double tTracked);
 extern "C" D3_RENDER_STREAM_API RS_ERROR rs_getFrameParameters(uint64_t schemaHash, /*Out*/void* outParameterData, uint64_t outParameterDataSize);  // returns the remote parameters for this frame.
 extern "C" D3_RENDER_STREAM_API RS_ERROR rs_getFrameImageData(uint64_t schemaHash, /*Out*/ImageFrameData* outParameterData, uint64_t outParameterDataCount);  // returns the remote image data for this frame.
 extern "C" D3_RENDER_STREAM_API RS_ERROR rs_getFrameImage2(int64_t imageId, /*InOut*/ const SenderFrame* frame); // fills in (data) with the remote image
+extern "C" D3_RENDER_STREAM_API RS_ERROR rs_registerTextureParams(); // processes texture parameter registrations, must be called from a render thread
 extern "C" D3_RENDER_STREAM_API RS_ERROR rs_getFrameText(uint64_t schemaHash, uint32_t textParamIndex, /*Out*/const char** outTextPtr); // // returns the remote text data (pointer only valid until next rs_awaitFrameData)
 
 extern "C" D3_RENDER_STREAM_API RS_ERROR rs_getFrameCamera(StreamHandle streamHandle, /*Out*/CameraData* outCameraData);  // returns the CameraData for this stream, or RS_ERROR_NOTFOUND if no camera data is available for this stream on this frame

--- a/src/include/renderstream.hpp
+++ b/src/include/renderstream.hpp
@@ -113,6 +113,8 @@ public:
     
     inline void getFrameImage(int64_t imageId, /*InOut*/const SenderFrame& data);
 
+    inline void registerTextureParams(); // processes texture parameter registrations, must be called from a render thread
+
     inline std::variant<FrameData, RS_ERROR> awaitFrameData(int timeoutMs);
 
     inline const StreamDescriptions* getStreams();
@@ -157,6 +159,7 @@ private:
     DECL_FN(getFrameImageData);
     DECL_FN(getFrameText);
     DECL_FN(getFrameImage2);
+    DECL_FN(registerTextureParams);
     DECL_FN(awaitFrameData);
     DECL_FN(getFrameCamera);
     DECL_FN(sendFrame2);
@@ -224,6 +227,7 @@ void RenderStream::initialise()
     LOAD_FN(getFrameImageData);
     LOAD_FN(getFrameText);
     LOAD_FN(getFrameImage2);
+    LOAD_FN(registerTextureParams);
     LOAD_FN(getStreams);
     LOAD_FN(awaitFrameData);
     LOAD_FN(getFrameCamera);
@@ -322,6 +326,11 @@ ParameterValues RenderStream::getFrameParameters(const RemoteParameters& scene)
 void RenderStream::getFrameImage(int64_t imageId, const SenderFrame& frame)
 {
     checkRs(m_getFrameImage2(imageId, &frame), __FUNCTION__);
+}
+
+void RenderStream::registerTextureParams()
+{
+    checkRs(m_registerTextureParams(), __FUNCTION__);
 }
 
 std::variant<FrameData, RS_ERROR> RenderStream::awaitFrameData(int timeoutMs)


### PR DESCRIPTION
[DSOF-30790](https://d3technologies.atlassian.net/browse/DSOF-30790)

**Related PRs:**
d3 - https://github.com/disguise-one/d3/pull/5933/
Plugin - https://github.com/disguise-one/RenderStream-UE/pull/140

**Note:** 
Need to update supporting d3 version info when we release RS3.0

[DSOF-30790]: https://d3technologies.atlassian.net/browse/DSOF-30790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new texture parameter registration API intended for render-thread use
  * Extended the schema to include a project working colour space field
* **Documentation**
  * Updated the changelog entry to target disguise designer version r33.3+ and documented the new texture parameter requirements
<!-- end of auto-generated comment: release notes by coderabbit.ai -->