### PR TITLE
Support for float array parameter type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 Compatible with disguise designer version rXX.x(need to be updated before releasing RS3.0) and above.
 * Added project working colour space in schema
 * When using texture parameters, the engine is required to call `rs_registerTextureParams` to register the received frames before they are used. This must be called from a render thread.
+* Added support for float array parameters (`RS_PARAMETER_ARRAY`).
+    * The `RemoteParameter` struct now ends with a `uint32_t nElements` field, denoting the number of elements in the parameter
 
 # RS2.0
 Compatible with disguise designer version r25.0 and above.

--- a/src/include/d3renderstream.h
+++ b/src/include/d3renderstream.h
@@ -241,6 +241,7 @@ enum RemoteParameterType
     RS_PARAMETER_TEXT,
     RS_PARAMETER_EVENT,
     RS_PARAMETER_SKELETON,
+    RS_PARAMETER_ARRAY,     // array of floats
 };
 
 enum RemoteParameterDmxType
@@ -302,6 +303,7 @@ typedef struct
     int32_t dmxOffset; // DMX channel offset or auto (-1)
     RemoteParameterDmxType dmxType;
     uint32_t flags; // REMOTEPARAMETER_FLAGS
+    uint32_t nElements; // used primarily for denoting the size of RS_PARAMETER_ARRAY
 } RemoteParameter;
 
 typedef struct


### PR DESCRIPTION
[RSP-385](https://d3technologies.atlassian.net/browse/RSP-385)

**Description:**
Added docs for newly added float array parameter support. Will be released as part of RS3.0.

[RSP-385]: https://d3technologies.atlassian.net/browse/RSP-385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ